### PR TITLE
Comment the persistence volume

### DIFF
--- a/01-deploying-traefik/values.yaml
+++ b/01-deploying-traefik/values.yaml
@@ -16,13 +16,16 @@ additionalArguments:
   - "--certificatesresolvers.le.acme.email=<REPLACE_ME>"
   - "--certificatesresolvers.le.acme.storage=/data/acme.json"
 
-persistence:
-  enabled: true
-  name: data
-  accessMode: ReadWriteOnce
-  size: 128Mi
-  path: /data
-
 logs:
   access:
     enabled: true
+
+# You can enable the persistence to store the ACME JSON file and avoid creating new certificates each time Traefik is restarted.
+# However, depending on your Kubernetes distribution, it could block the helm upgrade operation and force you to uninstall and re-install Traefik.
+
+# persistence:
+#   enabled: true
+#   name: data
+#   accessMode: ReadWriteOnce
+#   size: 128Mi
+#   path: /data

--- a/02-deploying-sample/ingress-route.yaml
+++ b/02-deploying-sample/ingress-route.yaml
@@ -7,7 +7,7 @@ spec:
     - websecure
   routes:
     - kind: Rule
-      match: Host(`<fixme>.demo.traefiklabs.tech`)
+      match: Host(`<MY_DOMAIN>`)
       services:
         - kind: Service
           name: whoamiv1

--- a/03-wrr/01-ingressroute.yaml
+++ b/03-wrr/01-ingressroute.yaml
@@ -9,7 +9,7 @@ spec:
      - websecure
   routes:
      - kind: Rule
-       match: Host(`<fixme>.demo.traefiklabs.tech`)
+       match: Host(`<MY_DOMAIN>`)
        services:
            - kind: TraefikService
              name: weighted-whoami

--- a/03-wrr/04-ingressroute-header.yaml
+++ b/03-wrr/04-ingressroute-header.yaml
@@ -9,7 +9,7 @@ spec:
      - websecure
   routes:
     - kind: Rule
-      match: Host(`<fixme>.demo.traefiklabs.tech`) && HeadersRegexp(`X-Canary-Header`, `knock-knock`)
+      match: Host(`<MY_DOMAIN>`) && HeadersRegexp(`X-Canary-Header`, `knock-knock`)
       services:
         - kind: Service
           name: whoamiv2

--- a/04-mirroring/01-ingressroute.yaml
+++ b/04-mirroring/01-ingressroute.yaml
@@ -9,7 +9,7 @@ spec:
      - websecure
   routes:
     - kind: Rule
-      match: Host(`<fixme>.demo.traefiklabs.tech`)
+      match: Host(`<MY_DOMAIN>`)
       services:
         - kind: TraefikService
           name: mirror-whoami

--- a/05-sticky-session/01-ingressroute.yaml
+++ b/05-sticky-session/01-ingressroute.yaml
@@ -9,7 +9,7 @@ spec:
      - websecure
   routes:
     - kind: Rule
-      match: Host(`<fixme>.demo.traefiklabs.tech`)
+      match: Host(`<MY_DOMAIN>`)
       services:
         - kind: TraefikService 
           name: whoami-sticky-session

--- a/06-nested-healthchecks/traefik-configs.yaml
+++ b/06-nested-healthchecks/traefik-configs.yaml
@@ -37,7 +37,7 @@ data:
         whoami-router:
           entryPoints:
             - websecure
-          rule: Host(`nested.w1.demo.traefiklabs.tech`)
+          rule: Host(`<MY_DOMAIN>`)
           service: whoami-public
           tls:
             certResolver: le

--- a/06-nested-healthchecks/values.yaml
+++ b/06-nested-healthchecks/values.yaml
@@ -17,13 +17,6 @@ additionalArguments:
   - "--certificatesresolvers.le.acme.storage=/data/acme.json"
   - "--providers.file.filename=/config/dynamic.yaml"
 
-persistence:
-  enabled: true
-  name: data
-  accessMode: ReadWriteOnce
-  size: 128Mi
-  path: /data
-
 logs:
   access:
     enabled: true
@@ -32,3 +25,13 @@ volumes:
   - name: '{{ printf "%s-configs" .Release.Name }}'
     mountPath: "/config"
     type: configMap
+
+# You can enable the persistence to store the ACME JSON file and avoid creating new certificates each time Traefik is restarted.
+# However, depending on your Kubernetes distribution, it could block the helm upgrade operation and force you to uninstall and re-install Traefik.
+
+# persistence:
+#   enabled: true
+#   name: data
+#   accessMode: ReadWriteOnce
+#   size: 128Mi
+#   path: /data


### PR DESCRIPTION
## Description

The 6th step of the practice session requires upgrading the Traefik deployment using Helm.
Depending on the Kubernetes distribution, the operation can be blocked because of persistence volume management.

To avoid blocking the users, this PR adds comments around the persistence definition.
The users can uncomment this definition if they want.